### PR TITLE
Renamed the language, the compiler is still zpiler..

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ tests/object/
 **.exe
 
 zlang-support/
+zust-support/
 
 **/.vscode/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zlang
+# zust
 
 A lightweight statically typed programming language that compiles to **x86_64 Linux assembly**, supporting custom data types, conditionals, arithmetic, and type-safe operations. The language was designed for educational and experimental purposes with an emphasis on low-level control and code generation.
 
@@ -21,7 +21,7 @@ A lightweight statically typed programming language that compiles to **x86_64 Li
 ## 📦 Project Structure
 
 ```
-zlang/
+zust/
 ├── include/
 │   ├── common/
 │   │   ├── Colors.hpp
@@ -95,8 +95,8 @@ zlang/
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-username/zlang.git
-cd zlang
+git clone https://github.com/your-username/zust.git
+cd zust
 
 # Create build directory
 mkdir build && cd build
@@ -177,9 +177,9 @@ gcc out.o -o out
 
 ---
 
-## 🧠 Example Program (zlang)
+## 🧠 Example Program (zust)
 
-```zlang
+```zust
 extern fn printf(fmt: string, ...) -> int32_t;
 
 fn factorial(x: uint64_t) -> uint64_t{

--- a/include/all.hpp
+++ b/include/all.hpp
@@ -1,33 +1,28 @@
 #pragma once
 
+#include <assert.h>
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+
+#include "ast/ASTNode.hpp"
+#include "codegen/Canaries.hpp"
+#include "codegen/CodeGen.hpp"
+#include "codegen/RegisterAllocator.hpp"
 #include "common/Colors.hpp"
 #include "common/Errors.hpp"
 #include "common/Logging.hpp"
 #include "common/StringUtils.hpp"
-
-#include "support/CommandLine.hpp"
-#include "support/File.hpp"
-
-#include "ast/ASTNode.hpp"
-
+#include "lexer/Lexer.hpp"
+#include "parser/NameMapper.hpp"
 #include "parser/Parser.hpp"
 #include "parser/ScopeContext.hpp"
-#include "parser/NameMapper.hpp"
-
-#include "lexer/Lexer.hpp"
-
+#include "support/CommandLine.hpp"
+#include "support/File.hpp"
 #include "typechecker/TypeChecker.hpp"
 
-#include "codegen/CodeGen.hpp"
-#include "codegen/RegisterAllocator.hpp"
-#include "codegen/Canaries.hpp"
-
-#include <sstream>
-#include <map>
-#include <iostream>
-#include <memory>
-#include <fstream>
-#include <assert.h>
-#include <iomanip>
-
-static NameMapper GLOBAL_NAME_MAPPER;
+static zust::NameMapper GLOBAL_NAME_MAPPER;

--- a/include/ast/ASTNode.hpp
+++ b/include/ast/ASTNode.hpp
@@ -7,7 +7,7 @@
 
 #include "parser/ScopeContext.hpp"
 
-namespace zlang {
+namespace zust {
     enum class NodeType {
         Program,
         VariableDeclaration,   // let x: int; or let x = 10;
@@ -73,4 +73,4 @@ namespace zlang {
         ASTNode *getFunctionBody() const;
         void print(std::ostream &out, int indent = 0) const;
     };
-}  // namespace zlang
+}  // namespace zust

--- a/include/codegen/Canaries.hpp
+++ b/include/codegen/Canaries.hpp
@@ -1,12 +1,14 @@
 #include <cstdint>
 #include <random>
 
-class CanaryGenerator {
-public:
-    static std::uint64_t generate() {
-        std::random_device rd;  // Cryptographically secure random source
-        std::mt19937_64 gen(rd());
-        std::uniform_int_distribution<std::uint64_t> dis;
-        return dis(gen);
-    }
-};
+namespace zust {
+    class CanaryGenerator {
+    public:
+        static std::uint64_t generate() {
+            std::random_device rd;  // Cryptographically secure random source
+            std::mt19937_64 gen(rd());
+            std::uniform_int_distribution<std::uint64_t> dis;
+            return dis(gen);
+        }
+    };
+}

--- a/include/codegen/CodeGen.hpp
+++ b/include/codegen/CodeGen.hpp
@@ -11,7 +11,7 @@
 #include "codegen/RegisterAllocator.hpp"
 #include "typechecker/TypeChecker.hpp"
 
-namespace zlang {
+namespace zust {
     enum class TargetTriple {
         X86_64_LINUX,
         X86_64_WINDOWS,
@@ -247,4 +247,4 @@ namespace zlang {
         CodeGenLLVM(std::ostream &outstream) : CodeGen(RegisterAllocator(), outstream) {};
         void generate(std::unique_ptr<ASTNode> program) override;
     };
-}  // namespace zlang
+}  // namespace zust

--- a/include/codegen/RegisterAllocator.hpp
+++ b/include/codegen/RegisterAllocator.hpp
@@ -7,7 +7,9 @@
 #include <unordered_set>
 #include <vector>
 
-namespace zlang {
+#include "support/CommandLine.hpp"
+
+namespace zust {
 
     // Tips for noobs: CALLER saved are saved by the caller, CALLEE saved are restored by the function/routine
     // So CALLER Union CALLEE should be equal to the set of all the registers, so the current state will never be corrupted.
@@ -78,11 +80,11 @@ namespace zlang {
         void markSpilled(const std::string &reg, const std::string &spillSlot);
         bool isSpilled(const std::string &reg) const;
         std::string spillSlotFor(const std::string &reg) const;
-        void unSpillXMM(const std::string &reg, zlang::CodegenOutputFormat format, std::ostream &out);
-        void unSpill(const std::string &reg, zlang::CodegenOutputFormat format, std::ostream &out);
+        void unSpillXMM(const std::string &reg, zust::CodegenOutputFormat format, std::ostream &out);
+        void unSpill(const std::string &reg, zust::CodegenOutputFormat format, std::ostream &out);
         void touch(const std::string &reg);
         void touchXMM(const std::string &reg);
-        void emitSpillRestore(const std::string &reg, const std::string &slot, bool isXMM, zlang::CodegenOutputFormat format, std::ostream &out);
+        void emitSpillRestore(const std::string &reg, const std::string &slot, bool isXMM, zust::CodegenOutputFormat format, std::ostream &out);
 
     private:
         RegisterAllocator(std::vector<std::string> regs, std::vector<std::string> XMMregs, std::vector<std::string> argumentRegs, std::vector<std::string> argumentXMMRegs);

--- a/include/common/Colors.hpp
+++ b/include/common/Colors.hpp
@@ -1,5 +1,5 @@
 #pragma once
-namespace zlang
+namespace zust
 {
     namespace colors
     {
@@ -13,4 +13,4 @@ namespace zlang
         constexpr const char *WHITE = "\033[0;37m";
     } // namespace colors
 
-} // namespace zlang
+} // namespace zust

--- a/include/common/Errors.hpp
+++ b/include/common/Errors.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-namespace zlang
+namespace zust
 {
     enum class ErrorType
     {
@@ -24,4 +24,4 @@ namespace zlang
         operator bool() const { return type != ErrorType::None; }
     };
 
-} // namespace zlang
+} // namespace zust

--- a/include/common/Logging.hpp
+++ b/include/common/Logging.hpp
@@ -3,11 +3,11 @@
 #include <string>
 #include "Errors.hpp"
 
-namespace zlang
+namespace zust
 {
 
     void logSystemError(const std::string &message);
     void logError(const Error &err);
     void logMessage(const std::string &message);
 
-} // namespace zlang
+} // namespace zust

--- a/include/common/StringUtils.hpp
+++ b/include/common/StringUtils.hpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-namespace zlang
+namespace zust
 {
 
     bool startsWith(const std::string &str, const std::string &prefix);
@@ -30,4 +30,4 @@ namespace zlang
         return isAlpha(c) || isDigit(c) || c == '_';
     }
 
-} // namespace zlang
+} // namespace zust

--- a/include/lexer/Lexer.hpp
+++ b/include/lexer/Lexer.hpp
@@ -4,7 +4,7 @@
 
 #include "../common/Errors.hpp"
 
-namespace zlang {
+namespace zust {
     struct Token {
         enum class Kind {
             Let,
@@ -106,7 +106,7 @@ namespace zlang {
     inline std::ostream &operator<<(std::ostream &os, const Token &token) {
         return os << token.to_string();
     }
-    using Error = zlang::Error;
+    using Error = zust::Error;
     class Lexer {
     public:
         explicit Lexer(const std::string &source);
@@ -130,4 +130,4 @@ namespace zlang {
         Token scanSymbol();
     };
 
-}  // namespace zlang
+}  // namespace zust

--- a/include/parser/NameMapper.hpp
+++ b/include/parser/NameMapper.hpp
@@ -2,23 +2,20 @@
 
 #include <string>
 
-class NameMapper
-    {
+namespace zust {
+    class NameMapper {
     public:
-        inline std::string mapVariable(const std::string &name, const std::string &scopeName)
-        {
+        inline std::string mapVariable(const std::string &name, const std::string &scopeName) {
             std::string mangled = scopeName + "___" + name + "___v" + std::to_string(varCounter_++);
             return mangled;
         }
 
-        inline std::string mapFunction(const std::string &name, const std::string &scopeName)
-        {
+        inline std::string mapFunction(const std::string &name, const std::string &scopeName) {
             std::string mangled = scopeName + "___" + name + "___f" + std::to_string(funcCounter_++);
             return mangled;
         }
 
-        inline std::string mapType(const std::string &name, const std::string &scopeName)
-        {
+        inline std::string mapType(const std::string &name, const std::string &scopeName) {
             std::string mangled = scopeName + "___" + name + "___t" + std::to_string(typeCounter_++);
             return mangled;
         }
@@ -28,3 +25,4 @@ class NameMapper
         size_t funcCounter_ = 0;
         size_t typeCounter_ = 0;
     };
+}

--- a/include/parser/Parser.hpp
+++ b/include/parser/Parser.hpp
@@ -7,7 +7,7 @@
 #include "common/Logging.hpp"
 #include "parser/ScopeContext.hpp"
 
-namespace zlang {
+namespace zust {
     class Parser {
     public:
         explicit Parser(Lexer &lexer);

--- a/include/parser/ScopeContext.hpp
+++ b/include/parser/ScopeContext.hpp
@@ -7,7 +7,9 @@
 #include <unordered_map>
 #include <vector>
 
-namespace zlang {
+#include "support/CommandLine.hpp"
+
+namespace zust {
     struct VariableInfo {
         std::string type;
     };
@@ -171,4 +173,4 @@ namespace zlang {
         }
     };
 
-}  // namespace zlang
+}  // namespace zust

--- a/include/support/CommandLine.hpp
+++ b/include/support/CommandLine.hpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-namespace zlang
+namespace zust
 {
 
     enum class CodegenOutputFormat
@@ -54,4 +54,4 @@ namespace zlang
         CodegenOutputFormat format = CodegenOutputFormat::Default;
     };
 
-} // namespace zlang
+} // namespace zust

--- a/include/support/File.hpp
+++ b/include/support/File.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <optional>
 
-namespace zlang
+namespace zust
 {
 
     class File
@@ -14,4 +14,4 @@ namespace zlang
         static std::optional<std::string> readAllText(const std::string &filepath);
     };
 
-} // namespace zlang
+} // namespace zust

--- a/include/typechecker/TypeChecker.hpp
+++ b/include/typechecker/TypeChecker.hpp
@@ -10,7 +10,7 @@
 
 // TODO: Check that all paths inside the function return appropriate value.
 
-namespace zlang {
+namespace zust {
     static const std::set<std::string> numeric_types = {"integer", "size_t", "uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"};
     static const std::set<std::string> integral_types = {"integer", "size_t", "uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t"};
 
@@ -89,4 +89,4 @@ namespace zlang {
         bool shouldCodegen_ = true;
     };
 
-}  // namespace zlang
+}  // namespace zust

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-using namespace zlang;
+using namespace zust;
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {
@@ -29,14 +29,14 @@ int main(int argc, char *argv[]) {
     assert(inputFile.ends_with(".zz"));
 
     if (inputFile.empty()) {
-        logError(zlang::Error(zlang::ErrorType::Generic, "No input files."));
+        logError(zust::Error(zust::ErrorType::Generic, "No input files."));
         CommandLine::printUsage(argv[0]);
         return 1;
     }
 
-    std::optional<std::string> source = zlang::File::readAllText(inputFile);
+    std::optional<std::string> source = zust::File::readAllText(inputFile);
     if (!source) {
-        logError(zlang::Error(zlang::ErrorType::Generic,
+        logError(zust::Error(zust::ErrorType::Generic,
                               "Failed to read from " + inputFile));
         return 1;
     }
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (!program.get()) {
-        zlang::logError(Error(ErrorType::Generic, "Parsing Failed"));
+        zust::logError(Error(ErrorType::Generic, "Parsing Failed"));
         return 1;
     }
     if (cli.printAST()) {
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
         outstream = &ofs;  // now point at the file
     }
 
-    std::unique_ptr<zlang::CodeGen> cg =
+    std::unique_ptr<zust::CodeGen> cg =
         CodeGen::create(TargetTriple::X86_64_LINUX, *outstream);
 
     switch (cli.getFormat()) {

--- a/src/ast/ASTNode.cpp
+++ b/src/ast/ASTNode.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-namespace zlang {
+namespace zust {
     std::unique_ptr<ASTNode> ASTNode::makeProgramNode(const std::shared_ptr<ScopeContext> scope) {
         return std::make_unique<ASTNode>(NodeType::Program, "", scope);
     }

--- a/src/codegen/CodeGen.cpp
+++ b/src/codegen/CodeGen.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-namespace zlang {
+namespace zust {
     CodeGen::~CodeGen() = default;
     std::unique_ptr<CodeGen> CodeGen::create(TargetTriple target, std::ostream &outstream) {
         switch (target) {

--- a/src/codegen/CodeGenLLVM.cpp
+++ b/src/codegen/CodeGenLLVM.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-namespace zlang {
+namespace zust {
 
     std::string llvmTypeName(const std::string &typeName) {
         if (typeName == "boolean")
@@ -565,8 +565,8 @@ namespace zlang {
         out << endLbl << ":\n";
     }
     void CodeGenLLVM::generate(std::unique_ptr<ASTNode> program) {
-        outGlobalStream << "; ModuleID = 'zlang'\n"
-                        << "source_filename = \"zlang\"\n\n";
+        outGlobalStream << "; ModuleID = 'zust'\n"
+                        << "source_filename = \"zust\"\n\n";
 
         // Globals
         for (auto &stmt : program->children) {
@@ -785,4 +785,4 @@ namespace zlang {
         std::string llvmTy = llvmTypeName(expected.name);
         out << "  ret " << llvmTy << " " << casted << "\n";
     }
-}  // namespace zlang
+}  // namespace zust

--- a/src/codegen/CodeGenLinux.cpp
+++ b/src/codegen/CodeGenLinux.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-namespace zlang {
+namespace zust {
     std::string CodeGenLinux::castValue(
         const std::string &val,
         const TypeInfo &fromType,
@@ -134,9 +134,9 @@ namespace zlang {
         std::string slot = alloc.spillSlotFor(reg);
 
         if (reg.starts_with("xm")) {
-            alloc.unSpillXMM(reg, zlang::CodegenOutputFormat::X86_64_LINUX, out);
+            alloc.unSpillXMM(reg, zust::CodegenOutputFormat::X86_64_LINUX, out);
         } else {
-            alloc.unSpill(reg, zlang::CodegenOutputFormat::X86_64_LINUX, out);
+            alloc.unSpill(reg, zust::CodegenOutputFormat::X86_64_LINUX, out);
         }
 
         auto result_scope = scope->findEnclosingFunctionScope();
@@ -1051,7 +1051,7 @@ namespace zlang {
         alloc.free(casted);
         emitEpilogue(funcScope, out);
     }
-}  // namespace zlang
+}  // namespace zust
 
 // TODO: Dont nest the code generation of nested functions.
 // This leads to disasters.

--- a/src/codegen/CodeGenWindows.cpp
+++ b/src/codegen/CodeGenWindows.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-namespace zlang {
+namespace zust {
     std::string CodeGenWindows::castValue(const std::string &val,
                                           const TypeInfo &fromType,
                                           const TypeInfo &toType, const std::shared_ptr<ScopeContext> currentScope, std::ostringstream &out) {
@@ -78,8 +78,7 @@ namespace zlang {
                             "Unsupported unsigned cast: " +
                             std::to_string(fromType.bits) +
                             " -> " +
-                            std::to_string(toType.bits)
-                        );
+                            std::to_string(toType.bits));
                     }
                 }
 
@@ -95,7 +94,6 @@ namespace zlang {
             noteType(dst, toType);
             return dst;
         }
-
 
         throw std::runtime_error(
             "Unsupported cast from " +
@@ -199,8 +197,7 @@ namespace zlang {
     }
     std::string CodeGenWindows::generateStringLiteral(
         std::unique_ptr<ASTNode> node,
-        std::ostringstream &out
-    ) {
+        std::ostringstream &out) {
         // 1) Create a unique label
         std::string lbl = "Lstr" + std::to_string(stringLabelCount++);
 
@@ -215,15 +212,25 @@ namespace zlang {
             if (raw[i] == '\\' && i + 1 < raw.size()) {
                 char esc = raw[++i];
                 switch (esc) {
-                    case 'n':  nums.push_back(0x0A); break;
-                    case 't':  nums.push_back(0x09); break;
-                    case '\\': printable.push_back('\\'); break;
-                    case '"':  printable.push_back('"');  break;
-                    case '0':  nums.push_back(0x00); break;
-                    default:
-                        // Unknown escape: emit literally
-                        printable.push_back('\\');
-                        printable.push_back(esc);
+                case 'n':
+                    nums.push_back(0x0A);
+                    break;
+                case 't':
+                    nums.push_back(0x09);
+                    break;
+                case '\\':
+                    printable.push_back('\\');
+                    break;
+                case '"':
+                    printable.push_back('"');
+                    break;
+                case '0':
+                    nums.push_back(0x00);
+                    break;
+                default:
+                    // Unknown escape: emit literally
+                    printable.push_back('\\');
+                    printable.push_back(esc);
                 }
             } else {
                 printable.push_back(raw[i]);
@@ -240,9 +247,12 @@ namespace zlang {
         if (!printable.empty()) {
             outGlobalStream << "\"";
             for (unsigned char c : printable) {
-                if (c == '"')       outGlobalStream << "\"\"";   // MASM doubles quotes
-                else if (c == '\\') outGlobalStream << "\\\\"; // literal backslash
-                else                outGlobalStream << c;
+                if (c == '"')
+                    outGlobalStream << "\"\"";  // MASM doubles quotes
+                else if (c == '\\')
+                    outGlobalStream << "\\\\";  // literal backslash
+                else
+                    outGlobalStream << c;
             }
             outGlobalStream << "\"";
 
@@ -557,7 +567,7 @@ namespace zlang {
         std::string s = oss.str();
         if (!s.empty()) {
             char first = s[0];
-            if ((first >= 'a' && first <= 'f') || 
+            if ((first >= 'a' && first <= 'f') ||
                 (first >= 'A' && first <= 'F')) {
                 s = "0" + s;
             }
@@ -775,19 +785,19 @@ namespace zlang {
             }
         } else {
             switch (sz) {
-                case 1:
-                    out << "    mov     BYTE PTR " << mem << ", " << r << "\n";
-                    break;
-                case 2:
-                    out << "    mov     WORD PTR " << mem << ", " << r << "\n";
-                    break;
-                case 4:
-                    out << "    mov     DWORD PTR " << mem << ", " << r << "\n";
-                    break;
-                case 8:
-                default:
-                    out << "    mov     QWORD PTR " << mem << ", " << r << "\n";
-                    break;
+            case 1:
+                out << "    mov     BYTE PTR " << mem << ", " << r << "\n";
+                break;
+            case 2:
+                out << "    mov     WORD PTR " << mem << ", " << r << "\n";
+                break;
+            case 4:
+                out << "    mov     DWORD PTR " << mem << ", " << r << "\n";
+                break;
+            case 8:
+            default:
+                out << "    mov     QWORD PTR " << mem << ", " << r << "\n";
+                break;
             }
         }
 
@@ -802,8 +812,8 @@ namespace zlang {
 
         // Compute memory operand
         std::string mem = scp.isGlobalVariable(name)
-            ? ("[" + name + "]")
-            : ("[rbp - " + std::to_string(std::abs(scp.getVariableOffset(name))) + "]");
+                              ? ("[" + name + "]")
+                              : ("[rbp - " + std::to_string(std::abs(scp.getVariableOffset(name))) + "]");
 
         // Lambda to emit store
         auto emitStore = [&](const std::string &r) {
@@ -815,19 +825,19 @@ namespace zlang {
                 }
             } else {
                 switch (sz) {
-                    case 1:
-                        out << "    mov     BYTE PTR " << mem << ", " << adjustReg(r, sz*8) << "\n";
-                        break;
-                    case 2:
-                        out << "    mov     WORD PTR " << mem << ", " << adjustReg(r, sz*8) << "\n";
-                        break;
-                    case 4:
-                        out << "    mov     DWORD PTR " << mem << ", " << adjustReg(r, sz*8) << "\n";
-                        break;
-                    case 8:
-                    default:
-                        out << "    mov     QWORD PTR " << mem << ", " << adjustReg(r, sz*8) << "\n";
-                        break;
+                case 1:
+                    out << "    mov     BYTE PTR " << mem << ", " << adjustReg(r, sz * 8) << "\n";
+                    break;
+                case 2:
+                    out << "    mov     WORD PTR " << mem << ", " << adjustReg(r, sz * 8) << "\n";
+                    break;
+                case 4:
+                    out << "    mov     DWORD PTR " << mem << ", " << adjustReg(r, sz * 8) << "\n";
+                    break;
+                case 8:
+                default:
+                    out << "    mov     QWORD PTR " << mem << ", " << adjustReg(r, sz * 8) << "\n";
+                    break;
                 }
             }
         };
@@ -850,20 +860,20 @@ namespace zlang {
             } else {
                 // Zero-initialize integer of size sz
                 switch (sz) {
-                    case 1:
-                        out << "    mov     BYTE PTR " << mem << ", 0\n";
-                        break;
-                    case 2:
-                        out << "    mov     WORD PTR " << mem << ", 0\n";
-                        break;
-                    case 4:
-                        out << "    mov     DWORD PTR " << mem << ", 0\n";
-                        break;
-                    case 8:
-                    default:
-                        out << "    xor     rax, rax\n";
-                        out << "    mov     QWORD PTR " << mem << ", rax\n";
-                        break;
+                case 1:
+                    out << "    mov     BYTE PTR " << mem << ", 0\n";
+                    break;
+                case 2:
+                    out << "    mov     WORD PTR " << mem << ", 0\n";
+                    break;
+                case 4:
+                    out << "    mov     DWORD PTR " << mem << ", 0\n";
+                    break;
+                case 8:
+                default:
+                    out << "    xor     rax, rax\n";
+                    out << "    mov     QWORD PTR " << mem << ", rax\n";
+                    break;
                 }
             }
         }
@@ -944,7 +954,7 @@ namespace zlang {
         out << endLbl << ":\n\n";
     }
     void CodeGenWindows::generate(std::unique_ptr<ASTNode> program) {
-        std::vector<ASTNode*> globals;
+        std::vector<ASTNode *> globals;
 
         // collect globals
         for (auto &stmt : program->children) {
@@ -955,11 +965,9 @@ namespace zlang {
 
         // --- .DATA segment (read-write globals) ---
         outGlobalStream << ".data\n\n";
-        for (auto &g : globals)
-        {
+        for (auto &g : globals) {
             TypeInfo info = g->scope->lookupType(g->children[0]->value);
-            switch (info.bits / 8)
-            {
+            switch (info.bits / 8) {
             case 8:
                 outGlobalStream << g->value << " QWORD 0\n";
                 break;
@@ -978,17 +986,17 @@ namespace zlang {
         }
 
         outGlobalStream << "\n.const\n";
-        
+
         // --- .CODE segment ---
         outStream << ".code\n";
 
         // emit stack-smash handler (define only, no EXTERN)
         outStream << "__stack_smash_detected PROC\n"
-                << "    mov     rax, 60       ; syscall: exit\n"
-                << "    mov     rdi, 69       ; exit code\n"
-                << "    syscall\n"
-                << "    ret\n"
-                << "__stack_smash_detected ENDP\n\n";
+                  << "    mov     rax, 60       ; syscall: exit\n"
+                  << "    mov     rdi, 69       ; exit code\n"
+                  << "    syscall\n"
+                  << "    ret\n"
+                  << "__stack_smash_detected ENDP\n\n";
 
         // collect main and top-level init statements
         std::unique_ptr<ASTNode> mainFn;
@@ -996,8 +1004,7 @@ namespace zlang {
         for (auto &stmt : program->children) {
             if (stmt->type == NodeType::Function && stmt->value == "main") {
                 mainFn = std::move(stmt);
-            } else if (stmt->type == NodeType::VariableDeclaration || stmt->type == NodeType::VariableReassignment
-                    || (stmt->type == NodeType::UnaryOp && (stmt->value == "++" || stmt->value == "--"))) {
+            } else if (stmt->type == NodeType::VariableDeclaration || stmt->type == NodeType::VariableReassignment || (stmt->type == NodeType::UnaryOp && (stmt->value == "++" || stmt->value == "--"))) {
                 initStmts.push_back(std::move(stmt));
             } else {
                 generateStatement(std::move(stmt), outStream);
@@ -1015,9 +1022,9 @@ namespace zlang {
 
         // finalize with END directive
         outfinal << outGlobalStream.str()
-                << "; ============== Globals End Here ==============\n\n"
-                << outStream.str()
-                << "\nEND\n";
+                 << "; ============== Globals End Here ==============\n\n"
+                 << outStream.str()
+                 << "\nEND\n";
     }
 
     std::string CodeGenWindows::generateFunctionCall(std::unique_ptr<ASTNode> node, std::ostringstream &out) {
@@ -1056,10 +1063,10 @@ namespace zlang {
         uint64_t gpCount = 0, xmmCount = 0, stackOff = 0;
         for (size_t i = 0; i < args.size(); ++i) {
             bool isFloat = (i < params.size())
-                            ? node->scope->lookupType(params[i].type).isFloat
-                            : (fnInfo.isVariadic ? false
+                               ? node->scope->lookupType(params[i].type).isFloat
+                               : (fnInfo.isVariadic ? false
                                                     : throw std::runtime_error(
-                                                        "Too many args"));
+                                                          "Too many args"));
             if (!isFloat) {
                 if (gpCount < ARG_GPR_MSVC.size())
                     gpCount++;
@@ -1094,10 +1101,10 @@ namespace zlang {
                 (i < params.size())
                     ? node->scope->lookupType(params[i].type)
                     : (fnInfo.isVariadic
-                        ? (passed.isFloat
-                                ? node->scope->lookupType("double")
-                                : node->scope->lookupType("int64_t"))
-                        : throw std::runtime_error("Too many args"));
+                           ? (passed.isFloat
+                                  ? node->scope->lookupType("double")
+                                  : node->scope->lookupType("int64_t"))
+                           : throw std::runtime_error("Too many args"));
             std::string cvt = castValue(src, passed, expect, node->scope, out);
             restoreIfSpilled(cvt, node->scope, out);
 
@@ -1146,7 +1153,7 @@ namespace zlang {
 
                 // CORRECTED: Use argument index (i) instead of xmmCount
                 if (fnInfo.isVariadic && i < 4) {
-                    static const std::vector<std::string> VARIADIC_FLOAT_GPRS = { "rcx", "rdx", "r8", "r9" };
+                    static const std::vector<std::string> VARIADIC_FLOAT_GPRS = {"rcx", "rdx", "r8", "r9"};
                     std::string gprDst = VARIADIC_FLOAT_GPRS[i];
                     out << "    movq    " << gprDst << ", " << dst << "    ; duplicate variadic float to GPR\n";
                     // Record for shadow space duplication
@@ -1218,8 +1225,8 @@ namespace zlang {
 
         return holder;
     }
-    
-    void CodeGenWindows::generateFunctionDeclaration(std::unique_ptr<ASTNode> node, std::ostringstream &out, bool force) {        
+
+    void CodeGenWindows::generateFunctionDeclaration(std::unique_ptr<ASTNode> node, std::ostringstream &out, bool force) {
         if (node->value == "main" && !force)
             return;
 
@@ -1232,7 +1239,7 @@ namespace zlang {
         if (!funcScope)
             throw std::runtime_error("Expected FunctionScope for function declaration");
 
-        if(!force)
+        if (!force)
             out << fnInfo.label << " PROC\n";
 
         // Generate parameter moves into locals ([rbp - offset])
@@ -1297,7 +1304,6 @@ namespace zlang {
             }
         }
 
-
         emitPrologue(funcScope, prologue);
 
         // If void return, emit epilogue after body
@@ -1320,8 +1326,8 @@ namespace zlang {
         }
 
         // End PROC
-        if(!force)
-        out << fnInfo.label << " ENDP\n\n";
+        if (!force)
+            out << fnInfo.label << " ENDP\n\n";
     }
     void CodeGenWindows::generateExternFunctionDeclaration(std::unique_ptr<ASTNode> node, std::ostringstream &out) {
         auto fnInfo = node->scope->lookupFunction(node->value);
@@ -1357,4 +1363,4 @@ namespace zlang {
         alloc.free(casted);
         emitEpilogue(funcScope, out);
     }
-}  // namespace zlang
+}  // namespace zust

--- a/src/codegen/RegisterAllocator.cpp
+++ b/src/codegen/RegisterAllocator.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-namespace zlang {
+namespace zust {
     RegisterAllocator::RegisterAllocator(std::vector<std::string> regs, std::vector<std::string> XMMregs, std::vector<std::string> argumentRegs, std::vector<std::string> argumentXMMRegs)
         : available(std::move(regs)), availableXMM(std::move(XMMregs)), availableArgumentRegs(std::move(argumentRegs)), availableArgumentRegsXMM(std::move(argumentXMMRegs)) {
     }
@@ -161,7 +161,7 @@ namespace zlang {
         return it->second.spillSlot;
     }
 
-    void RegisterAllocator::unSpillXMM(const std::string &reg, zlang::CodegenOutputFormat format, std::ostream &out) {
+    void RegisterAllocator::unSpillXMM(const std::string &reg, zust::CodegenOutputFormat format, std::ostream &out) {
         auto it = spilledRegs.find(reg);
         if (it == spilledRegs.end())
             throw std::runtime_error("XMM reg not spilled: " + reg);
@@ -170,7 +170,7 @@ namespace zlang {
         spilledRegs.erase(it);
     }
 
-    void RegisterAllocator::unSpill(const std::string &reg, zlang::CodegenOutputFormat format, std::ostream &out) {
+    void RegisterAllocator::unSpill(const std::string &reg, zust::CodegenOutputFormat format, std::ostream &out) {
         auto it = spilledRegs.find(reg);
         if (it == spilledRegs.end())
             throw std::runtime_error("GPR reg not spilled: " + reg);
@@ -179,7 +179,7 @@ namespace zlang {
         spilledRegs.erase(it);
     }
 
-    void RegisterAllocator::emitSpillRestore(const std::string &reg, const std::string &slot, bool isXMM, zlang::CodegenOutputFormat format, std::ostream &out) {
+    void RegisterAllocator::emitSpillRestore(const std::string &reg, const std::string &slot, bool isXMM, zust::CodegenOutputFormat format, std::ostream &out) {
         if (format == CodegenOutputFormat::X86_64_LINUX) {
             if (isXMM)
                 out << "    movdqu " << slot << ", %" << reg << "\n";
@@ -207,4 +207,4 @@ namespace zlang {
             lruXMMRegs.push_back(reg);
         }
     }
-}  // namespace zlang
+}  // namespace zust

--- a/src/common/Logging.cpp
+++ b/src/common/Logging.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <system_error>
 
-namespace zlang
+namespace zust
 {
 
     void logSystemError(const std::string &message)
@@ -49,4 +49,4 @@ namespace zlang
                   << std::endl;
     }
 
-} // namespace zlang
+} // namespace zust

--- a/src/common/StringUtils.cpp
+++ b/src/common/StringUtils.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <sstream>
 
-namespace zlang
+namespace zust
 {
 
     bool startsWith(const std::string &str, const std::string &prefix)
@@ -42,4 +42,4 @@ namespace zlang
         return std::string(strBegin, strEnd);
     }
 
-} // namespace zlang
+} // namespace zust

--- a/src/lexer/Lexer.cpp
+++ b/src/lexer/Lexer.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-namespace zlang {
+namespace zust {
 
     Lexer::Lexer(const std::string &source)
         : source_(source), pos_(0), line_(1), column_(1) {
@@ -218,4 +218,4 @@ namespace zlang {
             return Token{Token::Kind::Symbol, text, startLine, startCol};
         }
     }
-}  // namespace zlang
+}  // namespace zust

--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -6,7 +6,7 @@
 // Structures
 // Stdlib
 
-namespace zlang {
+namespace zust {
     Parser::Parser(Lexer& lex) : lexer(lex) {
         currentScope = std::make_shared<NamespaceScope>("GLOBAL__SCOPE", nullptr);
         // TODO: This is controversial, lets make something in the near future that
@@ -483,8 +483,8 @@ namespace zlang {
         }
         if (initNode == nullptr) {
             TypeInfo ty = currentScope->lookupType(typeNode->value);
-            if (zlang::numeric_types.find(typeNode->value) !=
-                zlang::numeric_types.end()) {
+            if (zust::numeric_types.find(typeNode->value) !=
+                zust::numeric_types.end()) {
                 if (ty.isFloat) {
                     if (ty.bits == 32)
                         initNode =
@@ -664,4 +664,4 @@ namespace zlang {
             throw std::runtime_error("Scope underflow");
         currentScope = currentScope->parent();
     }
-}  // namespace zlang
+}  // namespace zust

--- a/src/parser/ScopeContext.cpp
+++ b/src/parser/ScopeContext.cpp
@@ -1,6 +1,6 @@
 #include <all.hpp>
 
-namespace zlang {
+namespace zust {
     bool ScopeContext::defineVariable(const std::string &name,
                                       const VariableInfo &info) {
         if (!parent_ || (parent_->kind() == "Namespace" && kind() != "Function")) {
@@ -264,4 +264,4 @@ namespace zlang {
         out << pad << kind() << " Scope: " << name_ << "\n";
         ScopeContext::printScope(out, indent + 2);
     }
-}  // namespace zlang
+}  // namespace zust

--- a/src/support/CommandLine.cpp
+++ b/src/support/CommandLine.cpp
@@ -3,7 +3,7 @@
 #include <cstring>
 #include <iostream>
 
-namespace zlang {
+namespace zust {
 
     CommandLine::CommandLine(int argc, char *argv[]) {
         parseArgs(argc, argv);
@@ -131,4 +131,4 @@ namespace zlang {
                   << " -> x86_64-linux\n";
     }
 
-}  // namespace zlang
+}  // namespace zust

--- a/src/support/File.cpp
+++ b/src/support/File.cpp
@@ -2,7 +2,7 @@
 #include <fstream>
 #include <sstream>
 
-namespace zlang
+namespace zust
 {
 
     std::optional<std::string> File::readAllText(const std::string &filepath)
@@ -25,4 +25,4 @@ namespace zlang
         return contents.str();
     }
 
-} // namespace zlang
+} // namespace zust

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -1,6 +1,6 @@
 #include "all.hpp"
 
-namespace zlang {
+namespace zust {
     void TypeChecker::check(const std::unique_ptr<ASTNode> &program) {
         if (!program || program->type != NodeType::Program) {
             logError({ErrorType::Type,
@@ -62,7 +62,7 @@ namespace zlang {
                 shouldCodegen_ = false;
                 return "";
             }
-            const std::vector<zlang::ParamInfo> &functionParams = functionInfo.paramTypes;
+            const std::vector<zust::ParamInfo> &functionParams = functionInfo.paramTypes;
             const std::vector<std::unique_ptr<ASTNode>> &functionArguments = node->children[0]->children;
 
             if (functionArguments.size() != functionParams.size()) {
@@ -332,4 +332,4 @@ namespace zlang {
         return isNumeric(ty);
     }
 
-}  // namespace zlang
+}  // namespace zust


### PR DESCRIPTION
## Summary by Sourcery

Rename the project and internal namespaces from "zlang" to "zust", update documentation and code references, and perform broad include cleanup and code-format harmonization.

Enhancements:
- Rename language and compiler namespaces, identifiers, and project references from "zlang" to "zust" across code, headers, and source files
- Reorganize include directives in all.hpp by grouping and ordering headers consistently
- Wrap CanaryGenerator and NameMapper classes in the zust namespace and remove the deprecated global NameMapper instance
- Harmonize code formatting throughout codegen, parser, lexer, and support modules by unifying brace styles, switch-case indentation, and stream insertion alignment

Documentation:
- Update README.md to reflect the renamed project "zust" and adjust usage instructions and examples accordingly